### PR TITLE
bootstrap导航栏增加下拉菜单配置

### DIFF
--- a/plugs/layout/bootstrap/templates/menu.html
+++ b/plugs/layout/bootstrap/templates/menu.html
@@ -1,12 +1,32 @@
 {{use "jquery", css_only=True}}
 {{
 def menu(current='home', menus=None):
-    for id, caption, link in menus or settings.LAYOUT.MENUS:
-        if id == current:
-            out.write('<li class="active"><a href="%s"><span>%s</span></a></li>' % (link, caption), escape=False)
+    for x in menus or settings.LAYOUT.MENUS:
+        if isinstance(x, dict) and x.get('subs', None):
+            out.write('<li class="dropdown%s">' % (' active' if x.get('name', '') == current else '') , escape=False)
+            out.write('<a class="dropdown-toggle" id="dLabel_%s" role="button" data-target="#" data-toggle="dropdown" href="#"><span>%s<b class="caret"></b></span></a>' % (x.get('name', ''), x.get('title', '')), escape=False)
+            out.write('<ul class="dropdown-menu" role="menu" aria-labelledby="dLabel_%s">' % (x.get('name', '')), escape=False)
+            for esub in x.get('subs', None):
+                if id == current:
+                    out.write('<li class="active"><a href="%s">%s</a></li>' % (esub.get('link', ''), esub.get('title', '')), escape=False)
+                else:
+                    out.write('<li><a href="%s">%s</a></li>' % (esub.get('link', ''), esub.get('title', '')), escape=False)
+                pass
+            pass
+            out.write('</ul>', escape=False)
         else:
-            out.write('<li><a href="%s"><span>%s</span></a></li>' % (link, caption), escape=False)
+            if isinstance(x, dict):
+                id, caption, link = x.get('name', ''), x.get('title', ''), x.get('link', '')
+            else:
+                id, caption, link = x
+            pass
+            if id == current:
+                out.write('<li class="active"><a href="%s"><span>%s</span></a>' % (link, caption), escape=False)
+            else:
+                out.write('<li><a href="%s"><span>%s</span></a>' % (link, caption), escape=False)
+            pass
         pass
+        out.write('</li>', escape=False)
     pass
 pass
 

--- a/plugs/menus/templates/inc_menu.html
+++ b/plugs/menus/templates/inc_menu.html
@@ -2,8 +2,8 @@
 {{link "menus/jquery.navgoco.css"}}
 {{link "menus/jquery.navgoco.js"}}
 
-{{def navigation(active='', check=None, id=None, _class=None):
-    out.write(functions.navigation(name='MAIN', active=active, check=check, id=id, _class=_class), escape=False)
+{{def navigation(name='MAIN', active='', check=None, id=None, _class=None):
+    out.write(functions.navigation(name=name, active=active, check=check, id=id, _class=_class), escape=False)
 pass
 }}
 


### PR DESCRIPTION
1.更新 layout/bootstrap 的menu方法，在原基础上提供导航栏下拉菜单。
下拉菜单在settings.LAYOUT.MENUS中的设置如下例子：
[LAYOUT]
MENUS <= [
    {'name':'request','title':'待处理的审批', 'link':'/review/list?status=0'},
    {'name':'myown', 'title':'我发起的审批', 'subs':[
        {'name':'request_all', 'title':'全部', 'link':''},
        {'name':'request_unfinished', 'title':'未处理完毕', 'link':''},
    ]},
    ('home', _('Home'), '/'),
    ('about', _('About'), '/about'),
]

2.修正menus中inc_menu.html方法navigation的菜单树名称不可自定义的问题。
