### PR TITLE
remove request.user.is_manager

### DIFF
--- a/plugs/user_admin/templates/UsersManageView/list.html
+++ b/plugs/user_admin/templates/UsersManageView/list.html
@@ -5,7 +5,7 @@
 {{end}}
 
 {{block content_tool}}
-{{if request.user.is_superuser or request.user.is_manager:}}
+{{if request.user.is_superuser:}}
     <a class="btn btn-blue" href="{{=url_for('plugs.user_admin.views_admin.UsersManageView.add')}}">{{=_('Click here to add new user.')}}</a>
 {{pass}}
 {{end}}


### PR DESCRIPTION
User object don't have this attribute.
Normal user access localhost:8000/users/list this access will error.

`    if request.user.is_superuser or request.user.is_manager:  # UsersManageView/list.html:8 (via layout.html:16, layout.html:14, bootstrap/bootstrap_layout.html:45)
AttributeError: 'User' object has no attribute 'is_manager'[INFO] 127.0.0.1 - - [01/Feb/2016 17:50:41] "GET /users/list HTTP/1.1" 500 -`